### PR TITLE
Fix: Added indention for case-block

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,10 +78,11 @@ style. Here are just some examples:
     case 1:
         // do something
         break;
-    case 2: {
-        // or something else, but in a block, if you need to
-        break;
-    }
+    case 2:
+        {
+            // or something else, but in a block, if you need to
+            break;
+        }
     default:
         // do whatever
         break;


### PR DESCRIPTION
We should indent this if we need a block inside a case-statement like
so, which is _much_ more readable for long switch(-case) blocks, as we do
not visually collide with the closing bracket of the switch block.
