### PR TITLE
Revert "Removed apostrophes"

### DIFF
--- a/paper/overview.tex
+++ b/paper/overview.tex
@@ -8,8 +8,8 @@
 
     This paper will discuss the algorithms used to implement each operation,
     drawing lines between the different levels, the overall hash-table and the
-    buckets that is. Each operations description will also include a short
-    derivation of the operations class of complexity.
+    buckets that is. Each operation's description will also include a short
+    derivation of the operation's class of complexity.
 
     Additionally, we will discuss the possible use of bloom filters within this
     data-structure for early deniablity of an elements occurrence in the set.


### PR DESCRIPTION
This reverts commit 39e5504d9b470c386fe412108b67a85ed6c0dba3, which was
introduced with #9, which I accidentally merged without removing the commit.
