### PR TITLE
Add hash.h hash utility

### DIFF
--- a/include/libreset/hash.h
+++ b/include/libreset/hash.h
@@ -5,6 +5,9 @@
 
 /**
  * The hash type
+ *
+ * The `rs_hash` type is guaranteed to be able to be handled with the normal
+ * comparators.
  */
 typedef rs_hash uint64_t;
 

--- a/include/libreset/hash.h
+++ b/include/libreset/hash.h
@@ -1,0 +1,12 @@
+#ifndef __LIBRESET_HASH_H__
+#define __LIBRESET_HASH_H__
+
+#include <stdint.h>
+
+/**
+ * The hash type
+ */
+typedef rs_hash uint64_t;
+
+#endif //__LIBRESET_HASH_H__
+

--- a/include/libreset/hash.h
+++ b/include/libreset/hash.h
@@ -1,7 +1,7 @@
 #ifndef __LIBRESET_HASH_H__
 #define __LIBRESET_HASH_H__
 
-#include <stdint.h>
+#include <stddef.h>
 
 /**
  * The hash type
@@ -9,7 +9,7 @@
  * The `rs_hash` type is guaranteed to be able to be handled with the normal
  * comparators.
  */
-typedef rs_hash uint64_t;
+typedef rs_hash size_t;
 
 #endif //__LIBRESET_HASH_H__
 


### PR DESCRIPTION
This adds the `src/libreset/hash.h` file, which is a utility for dealing
with hashes.

It defines the `rs_hash` type as well as it contains functions for
dealing with objects of this type.

Simplifies #12 
