### PR TITLE
Added ./u entries in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,12 @@ bject files
 
 *.backup
 
+#
+# Directory where the gentle programmer can put her/his utility snippets when
+# working with the codebase.
+#
+# For example, you can put vim scripts in there when working with vim, so you
+# can load them into your vim session and do work for you.
+#
+./u
+./u/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,5 +188,19 @@ If something was not mentioned here, have a look at
 [this](https://www.kernel.org/doc/Documentation/SubmittingPatches), we want to
 orientate on this kernel styleguide on how to submit patches.
 
+## Utility scripts
+
+We added a gitignore entry for `./u`, so you can simply put your utilities into
+this directory:
+
+```bash
+mkdir u
+mv /my/great/util.script ./u/
+```
+
+And you don't mess up the repository.
+
+## Contribute pizza!
+
 If you want to contribute without writing code, testing or writing
 documentation, feel free to order us some pizza.


### PR DESCRIPTION
This adds two entries in the .gitignore file:

```
./u
./u/*
```

for ignoring such a subdirectory. The gentle user is now able to put
her/his utility scripts in there.

For example, one could put an astyle helper (callastyle.sh) in there:

```
#!/bin/bash
astyle --options=./etc/astyle
```

as typing the astyle call by hand can be annoying.

---

I want this patch to go into the codebase, as I can for example put vim-ex snippets in this directory and call them from vim, so they can do work for me!
