### PR TITLE
Add node cnt

### DIFF
--- a/src/libreset/avl.h
+++ b/src/libreset/avl.h
@@ -41,10 +41,10 @@ struct avl {
  */
 struct avl_el {
     rs_hash hash;
-    struct ll ll;       //!< The linkedlist where the data elements are stored
-    signed int height;  //!< The height of the subtree
-    struct  avl_el* l;  //!< Next left node
-    struct  avl_el* r;  //!< Next right node
+    struct ll ll;           //!< The linkedlist where the data elements are stored
+    unsigned int height;    //!< The height of the subtree
+    struct  avl_el* l;      //!< Next left node
+    struct  avl_el* r;      //!< Next right node
 };
 
 /**

--- a/src/libreset/avl.h
+++ b/src/libreset/avl.h
@@ -139,6 +139,17 @@ avl_height(
 );
 
 
+/**
+ * Get the number of nodes a subtree contains
+ *
+ * @return The number of nodes the subtree contains
+ */
+inline static unsigned int
+avl_node_cnt(
+    struct avl_el* root //!< The root element
+);
+
+
 /*
  *
  *
@@ -157,6 +168,13 @@ avl_height(
     struct avl_el* root //!< The root element
 ) {
     return root == NULL ? 0 : root->height;
+}
+
+inline static unsigned int
+avl_node_cnt(
+    struct avl_el* root //!< The root element
+) {
+    return (root == NULL) ? 0 : (root->node_cnt);
 }
 
 /** @} */

--- a/src/libreset/avl.h
+++ b/src/libreset/avl.h
@@ -41,7 +41,7 @@ struct avl {
  */
 struct avl_el {
     rs_hash hash;
-    struct ll ll;           //!< The linkedlist where the data elements are stored
+    struct ll ll;           //!< The linked list containing stored elements
     unsigned int height;    //!< The height of the subtree
     struct  avl_el* l;      //!< Next left node
     struct  avl_el* r;      //!< Next right node

--- a/src/libreset/avl.h
+++ b/src/libreset/avl.h
@@ -132,7 +132,7 @@ avl_get_hash(
  *
  * @return The height of the avl sub tree
  */
-inline static signed int
+inline static unsigned int
 avl_height(
     struct avl_el* root //!< The root element
 );
@@ -151,7 +151,7 @@ avl_get_hash(struct avl_el* el) {
     return el->hash;
 }
 
-inline static signed int
+inline static unsigned int
 avl_height(
     struct avl_el* root //!< The root element
 ) {

--- a/src/libreset/avl.h
+++ b/src/libreset/avl.h
@@ -43,6 +43,7 @@ struct avl_el {
     rs_hash hash;
     struct ll ll;           //!< The linked list containing stored elements
     unsigned int height;    //!< The height of the subtree
+    unsigned int node_cnt;  //!< The number of nodes which are in the subtree
     struct  avl_el* l;      //!< Next left node
     struct  avl_el* r;      //!< Next right node
 };


### PR DESCRIPTION
This PR adds the number of nodes to the node's metadata.
Storing the number of nodes of a subtree will effectively speed up some operations.
