### PR TITLE
Add internal avl rotation functions

### DIFF
--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -131,25 +131,25 @@ rebalance_subtree(
     while (avl_node_cnt(root->r) > (2*avl_node_cnt(root->l)+1)) {
         // perform right-rotations in the right subtree if necessary
         while (avl_node_cnt(root->r->r) <= avl_node_cnt(root->l)) {
-            root->r=rotate_right(root->r);
+            root->r = rotate_right(root->r);
         }
 
-        root=rotate_left(root);
+        root = rotate_left(root);
     }
 
     // perform a right-rotation if there are too many nodes in the right subtree
     while (avl_node_cnt(root->l) > (2*avl_node_cnt(root->r)+1)) {
         // perform left-rotations in the right subtree if necessary
         while (avl_node_cnt(root->l->l) <= avl_node_cnt(root->r)) {
-            root->l=rotate_left(root->l);
+            root->l = rotate_left(root->l);
         }
 
-        root=rotate_right(root);
+        root = rotate_right(root);
     }
 
     // now rebalance the children
-    root->l=rebalance_subtree(root->l);
-    root->r=rebalance_subtree(root->r);
+    root->l = rebalance_subtree(root->l);
+    root->r = rebalance_subtree(root->r);
 
     return root;
 }

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -132,17 +132,17 @@ rotate_right(
 
     struct avl_el* new_root=node->l;
 
-    //relocate the middle subtree
+    // relocate the middle subtree
     node->l=new_root->r;
 
-    //old root node is now child of new root node
+    // old root node is now child of new root node
     new_root->r=node;
 
-    //regenerate the node's metadata
+    // regenerate the node's metadata
     regen_metadata(node);
     regen_metadata(new_root);
 
-    //return new root node
+    // return new root node
     return new_root;
 }
 

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -16,6 +16,26 @@ destroy_subtree(
     struct avl_el* node //!< A node to destroy
 );
 
+/**
+ * Rotate a node counter-clockwise
+ *
+ * @return new root or NULL, if the rotation could not be performed
+ */
+static struct avl_el*
+rotate_left(
+    struct avl_el* node //!< The node to rotate
+);
+
+/**
+ * Rotate a node clockwise
+ *
+ * @return new root or NULL, if the rotation could not be performed
+ */
+static struct avl_el*
+rotate_right(
+    struct avl_el* node //!< The node to rotate
+);
+
 
 /*
  *
@@ -64,3 +84,16 @@ destroy_subtree(
     free(node);
 }
 
+static struct avl_el*
+rotate_left(
+    struct avl_el* node
+) {
+    return 0;
+}
+
+static struct avl_el*
+rotate_right(
+    struct avl_el* node
+) {
+    return 0;
+}

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -108,17 +108,17 @@ rotate_left(
 
     struct avl_el* new_root=node->r;
 
-    //relocate the middle subtree
+    // relocate the middle subtree
     node->r=new_root->l;
 
-    //old root node is now child of new root node
+    // old root node is now child of new root node
     new_root->l=node;
 
-    //regenerate the node's metadata
+    // regenerate the node's metadata
     regen_metadata(node);
     regen_metadata(new_root);
 
-    //return new root node
+    // return new root node
     return new_root;
 }
 

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -130,7 +130,28 @@ static struct avl_el*
 rotate_right(
     struct avl_el* node
 ) {
-    return 0;
+    if (!node) {
+        return NULL;
+    }
+
+    if (!node->l) {
+        return NULL;
+    }
+
+    struct avl_el* new_root=node->l;
+
+    //relocate the middle subtree
+    node->l=new_root->r;
+
+    //old root node is now child of new root node
+    new_root->r=node;
+
+    //regenerate the node's metadata
+    regen_metadata(node);
+    regen_metadata(new_root);
+
+    //return new root node
+    return new_root;
 }
 
 static void

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -124,12 +124,13 @@ rebalance_subtree(
     }
 
     // check whether the subtrees is already balanced (see paper)
-    if (avl_node_cnt(root) > (unsigned int) (1 << (avl_height(root)-1) ) - 1) {
+    if (avl_node_cnt(root) >
+        (unsigned int) (1 << (avl_height(root) - 1) ) - 1) {
         return root;
     }
 
     // perform a left-rotation if there are too many nodes in the right subtree
-    while (avl_node_cnt(root->r) > (2*avl_node_cnt(root->l)+1)) {
+    while (avl_node_cnt(root->r) > (2 * avl_node_cnt(root->l) + 1)) {
         // perform right-rotations in the right subtree if necessary
         while (avl_node_cnt(root->r->r) <= avl_node_cnt(root->l)) {
             root->r = rotate_right(root->r);
@@ -139,7 +140,7 @@ rebalance_subtree(
     }
 
     // perform a right-rotation if there are too many nodes in the right subtree
-    while (avl_node_cnt(root->l) > (2*avl_node_cnt(root->r)+1)) {
+    while (avl_node_cnt(root->l) > (2 * avl_node_cnt(root->r) + 1)) {
         // perform left-rotations in the right subtree if necessary
         while (avl_node_cnt(root->l->l) <= avl_node_cnt(root->r)) {
             root->l = rotate_left(root->l);

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -36,6 +36,20 @@ rotate_right(
     struct avl_el* node //!< The node to rotate
 );
 
+/**
+ * Regenerate a node's height and node_cnt
+ *
+ * @return void
+ *
+ * This function regenerates the buffered metadata of a node with a depth of 1.
+ * The function does not recurse but only takes into account the metadata of
+ * direct children.
+ */
+static void
+regen_metadata(
+    struct avl_el* node //!< The node to regenerate
+);
+
 
 /*
  *
@@ -96,4 +110,11 @@ rotate_right(
     struct avl_el* node
 ) {
     return 0;
+}
+
+static void
+regen_metadata(
+    struct avl_el* node //!< The node to regenerate
+) {
+    //TODO: implement
 }

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -186,13 +186,13 @@ rotate_right(
         return NULL;
     }
 
-    struct avl_el* new_root=node->l;
+    struct avl_el* new_root = node->l;
 
     // relocate the middle subtree
-    node->l=new_root->r;
+    node->l = new_root->r;
 
     // old root node is now child of new root node
-    new_root->r=node;
+    new_root->r = node;
 
     // regenerate the node's metadata
     regen_metadata(node);

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -18,6 +18,20 @@ destroy_subtree(
 );
 
 /**
+ * Rebalance a subtree
+ *
+ * This function will recursively rebalance a subtree.
+ * It uses the metadata of a subtree's root node to check whether the subtree
+ * already is balanced. This way, unnecessary recursions are omitted.
+ *
+ * @return new root
+ */
+static struct avl_el*
+rebalance_subtree(
+    struct avl_el* root //!< The root of the subtree to rebalance
+);
+
+/**
  * Rotate a node counter-clockwise
  *
  * @return new root or NULL, if the rotation could not be performed
@@ -97,6 +111,47 @@ destroy_subtree(
     }
 
     free(node);
+}
+
+static struct avl_el*
+rebalance_subtree(
+    struct avl_el* root
+) {
+    //check whether the root node is NULL
+    if (!root) {
+        return NULL;
+    }
+
+    // check whether the subtrees is already balanced
+    if (avl_node_cnt(root) > (unsigned int) (1 << (avl_height(root)-1) ) - 1) {
+        return root;
+    }
+
+    // perform a left-rotation if there are too many nodes in the right subtree
+    while (avl_node_cnt(root->r) > (2*avl_node_cnt(root->l)+1)) {
+        // perform right-rotations in the right subtree if necessary
+        while (avl_node_cnt(root->r->r) <= avl_node_cnt(root->l)) {
+            root->r=rotate_right(root->r);
+        }
+
+        root=rotate_left(root);
+    }
+
+    // perform a right-rotation if there are too many nodes in the right subtree
+    while (avl_node_cnt(root->l) > (2*avl_node_cnt(root->r)+1)) {
+        // perform left-rotations in the right subtree if necessary
+        while (avl_node_cnt(root->l->l) <= avl_node_cnt(root->r)) {
+            root->l=rotate_left(root->l);
+        }
+
+        root=rotate_right(root);
+    }
+
+    // now rebalance the children
+    root->l=rebalance_subtree(root->l);
+    root->r=rebalance_subtree(root->r);
+
+    return root;
 }
 
 static struct avl_el*

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -102,11 +102,7 @@ static struct avl_el*
 rotate_left(
     struct avl_el* node
 ) {
-    if (!node) {
-        return NULL;
-    }
-
-    if (!node->r) {
+    if (!node || !node->r) {
         return NULL;
     }
 

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -122,7 +122,7 @@ rebalance_subtree(
         return NULL;
     }
 
-    // check whether the subtrees is already balanced
+    // check whether the subtrees is already balanced (see paper)
     if (avl_node_cnt(root) > (unsigned int) (1 << (avl_height(root)-1) ) - 1) {
         return root;
     }

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -126,11 +126,7 @@ static struct avl_el*
 rotate_right(
     struct avl_el* node
 ) {
-    if (!node) {
-        return NULL;
-    }
-
-    if (!node->l) {
+    if (!node || !node->l) {
         return NULL;
     }
 

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -150,10 +150,10 @@ static void
 regen_metadata(
     struct avl_el* node //!< The node to regenerate
 ) {
-    //regenerate the height
+    // regenerate the height
     node->height = 1 + avl_height(node->l) + avl_height(node->r);
 
-    //regenerate the node count
+    // regenerate the node count
     node->node_cnt = 1 + avl_node_cnt(node->l) + avl_node_cnt(node->r);
 }
 

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -162,13 +162,13 @@ rotate_left(
         return NULL;
     }
 
-    struct avl_el* new_root=node->r;
+    struct avl_el* new_root = node->r;
 
     // relocate the middle subtree
-    node->r=new_root->l;
+    node->r = new_root->l;
 
     // old root node is now child of new root node
-    new_root->l=node;
+    new_root->l = node;
 
     // regenerate the node's metadata
     regen_metadata(node);

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -55,6 +55,7 @@ rotate_right(
  * Regenerate a node's height and node_cnt
  *
  * @return void
+ * @warning This function will crash when being passed NULL.
  *
  * This function regenerates the buffered metadata of a node with a depth of 1.
  * The function does not recurse but only takes into account the metadata of

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 
 #include "avl.h"
+#include "util/macros.h"
 
 
 /*
@@ -151,7 +152,7 @@ regen_metadata(
     struct avl_el* node //!< The node to regenerate
 ) {
     // regenerate the height
-    node->height = 1 + avl_height(node->l) + avl_height(node->r);
+    node->height = 1 + MAX(avl_height(node->l), avl_height(node->r));
 
     // regenerate the node count
     node->node_cnt = 1 + avl_node_cnt(node->l) + avl_node_cnt(node->r);

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -117,7 +117,7 @@ static struct avl_el*
 rebalance_subtree(
     struct avl_el* root
 ) {
-    //check whether the root node is NULL
+    // check whether the root node is NULL
     if (!root) {
         return NULL;
     }

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -102,7 +102,28 @@ static struct avl_el*
 rotate_left(
     struct avl_el* node
 ) {
-    return 0;
+    if (!node) {
+        return NULL;
+    }
+
+    if (!node->r) {
+        return NULL;
+    }
+
+    struct avl_el* new_root=node->r;
+
+    //relocate the middle subtree
+    node->r=new_root->l;
+
+    //old root node is now child of new root node
+    new_root->l=node;
+
+    //regenerate the node's metadata
+    regen_metadata(node);
+    regen_metadata(new_root);
+
+    //return new root node
+    return new_root;
 }
 
 static struct avl_el*

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -158,5 +158,10 @@ static void
 regen_metadata(
     struct avl_el* node //!< The node to regenerate
 ) {
-    //TODO: implement
+    //regenerate the height
+    node->height = 1 + avl_height(node->l) + avl_height(node->r);
+
+    //regenerate the node count
+    node->node_cnt = 1 + avl_node_cnt(node->l) + avl_node_cnt(node->r);
 }
+


### PR DESCRIPTION
This PR adds functions for AVL rotations.
Note that a double rotation can be achieved by two consecutive rotations in oposite directions on a node's child and on the node itself afterwards.
