### PR TITLE
Implement avl find

### DIFF
--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -41,6 +41,23 @@ avl_destroy(
     return 1;
 }
 
+struct avl_el*
+avl_find(
+    struct avl* avl,
+    rs_hash hash
+) {
+    struct avl_el* iter = avl->root;
+
+    while (iter && iter->hash != hash) {
+        if (iter->hash > hash) {
+            iter = iter->l;
+        } else {
+            iter = iter->r;
+        }
+    }
+
+    return iter;
+}
 
 /*
  *

--- a/src/libreset/avl.h
+++ b/src/libreset/avl.h
@@ -107,15 +107,14 @@ avl_del(
 );
 
 /**
- * Find an element in a avl tree
+ * Find a node in a avl tree which has the passed hash
  *
- * @return The found element or NULL if there was nothing found
+ * @return The found node or NULL if there was nothing found
  */
 struct avl_el*
 avl_find(
-    struct avl* avl , //!< The avl where to search in
-    rs_predicate_function pred, //!< the predicate function
-    void* etc //!< an additional parameter to the predicate function
+    struct avl* avl, //!< The avl where to search in
+    rs_hash hash //!< The hash of the element to find
 );
 
 /**


### PR DESCRIPTION
Solves #57 

**Note:** We return a `struct avl_el*` here, so we do not search for an actual _element_ but a _node_ where the element we look for should be in.
