### PR TITLE
Add hard mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ install:
     - sudo update-alternatives --config gcc
 
 script:
-    - cmake .
+    - cmake -DHARD_MODE=ON .
     - make
     - make paper

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ find_program(DOXYGEN doxygen)
 
 
 #
+# Project options
+#
+option(HARD_MODE "Enables extra checks for use during development" OFF)
+
+
+#
 # Libreset's sources reside in ./src/.
 #
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,10 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wunused -Wformat")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-parameter -pedantic")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
 
+if(${HARD_MODE})
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror -Wno-error=unused-function")
+endif()
+
 #
 # Libreset will be a shared object
 #


### PR DESCRIPTION
This PR adds a "Hard mode" to be used in CI and (maybe) hooks.
Hard mode currently activates Werror, causing the compiler to abort compilation upon compiler warnings. Unused functions and arguments are excluded.
