### PR TITLE
Add libreset dependency to the test program's build

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,8 @@ target_link_libraries(check_tests
     ${PROJECT_SOURCE_DIR}/src/libreset.so)
 
 
+add_dependencies(check_tests reset)
+
 #
 # Ultimately, the test
 #


### PR DESCRIPTION
This PR enables users to run tests without having a complete build beforehand.
Solves issue #94.
