### PR TITLE
Add avl internal avl del prequisites

### DIFF
--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -69,9 +69,13 @@ isolate_root_node(
 );
 
 /**
- * Cut node with lowest key from subtree
+ * Isolate node with lowest key from subtree
  *
- * @return node with lowest key
+ * This function will isolate the node with the lowest key from the rest of the
+ * given subtree. The lowest key, in this implementation, is the leftmost node.
+ * The isolated node will be returned.
+ *
+ * @return node with lowest key, or NULL
  */
 static struct avl_el*
 isolate_lowest(

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -58,6 +58,16 @@ rotate_right(
 );
 
 /**
+ * Cut node with lowest key from subtree
+ *
+ * @return node with lowest key
+ */
+static struct avl_el*
+cut_lowest(
+    struct avl_el** root //!< Pointer to the root of the affected subtree
+);
+
+/**
  * Regenerate a node's height and node_cnt
  *
  * @return void
@@ -311,6 +321,31 @@ rotate_right(
 
     // return new root node
     return new_root;
+}
+
+static struct avl_el*
+cut_lowest(
+    struct avl_el** root
+) {
+    if (!root || !*root) {
+        return NULL;
+    }
+
+    // recurse
+    struct avl_el* retval = cut_lowest(&(*root)->l);
+
+    // if the recursion solved the problem already, we can return
+    if (retval) {
+        regen_metadata(*root);
+        return retval;
+    }
+
+    // else the lowest element is the one at hand
+    retval = *root;
+
+    // all that is left to do is cutting the element loose
+    *root = retval->r;
+    return retval;
 }
 
 static void

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -58,6 +58,17 @@ rotate_right(
 );
 
 /**
+ * Isolate the root node of a given subtree
+ *
+ * @return the new root node for the tree of which the old one was the root
+ * @warning This function will crash when being passed NULL.
+ */
+static struct avl_el*
+isolate_root_node(
+    struct avl_el* node //!< node to remove
+);
+
+/**
  * Cut node with lowest key from subtree
  *
  * @return node with lowest key
@@ -320,6 +331,31 @@ rotate_right(
     regen_metadata(new_root);
 
     // return new root node
+    return new_root;
+}
+
+static struct avl_el*
+isolate_root_node(
+    struct avl_el* node
+) {
+    // if the node has no left child, we may use the right one
+    if (!node->l) {
+        return node->r;
+    }
+
+    // assume that a suitable replacement exists in the right subtree
+    struct avl_el* new_root = cut_lowest(&node->r);
+
+    // seems like a replacement does not exist. The right subtree must be empty
+    if (!new_root) {
+        return node->l;
+    }
+
+    // insert the new node
+    new_root->l = node->l;
+    new_root->r = node->r;
+    regen_metadata(new_root);
+
     return new_root;
 }
 

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -74,7 +74,7 @@ isolate_root_node(
  * @return node with lowest key
  */
 static struct avl_el*
-cut_lowest(
+isolate_lowest(
     struct avl_el** root //!< Pointer to the root of the affected subtree
 );
 
@@ -344,7 +344,7 @@ isolate_root_node(
     }
 
     // assume that a suitable replacement exists in the right subtree
-    struct avl_el* new_root = cut_lowest(&node->r);
+    struct avl_el* new_root = isolate_lowest(&node->r);
 
     // seems like a replacement does not exist. The right subtree must be empty
     if (!new_root) {
@@ -360,7 +360,7 @@ isolate_root_node(
 }
 
 static struct avl_el*
-cut_lowest(
+isolate_lowest(
     struct avl_el** root
 ) {
     if (!root || !*root) {
@@ -368,7 +368,7 @@ cut_lowest(
     }
 
     // recurse
-    struct avl_el* retval = cut_lowest(&(*root)->l);
+    struct avl_el* retval = isolate_lowest(&(*root)->l);
 
     // if the recursion solved the problem already, we can return
     if (retval) {

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -78,7 +78,7 @@ isolate_root_node(
  * @return node with lowest key, or NULL
  */
 static struct avl_el*
-isolate_lowest(
+isolate_leftmost(
     struct avl_el** root //!< Pointer to the root of the affected subtree
 );
 
@@ -348,7 +348,7 @@ isolate_root_node(
     }
 
     // assume that a suitable replacement exists in the right subtree
-    struct avl_el* new_root = isolate_lowest(&node->r);
+    struct avl_el* new_root = isolate_leftmost(&node->r);
 
     // seems like a replacement does not exist. The right subtree must be empty
     if (!new_root) {
@@ -364,7 +364,7 @@ isolate_root_node(
 }
 
 static struct avl_el*
-isolate_lowest(
+isolate_leftmost(
     struct avl_el** root
 ) {
     if (!root || !*root) {
@@ -372,7 +372,7 @@ isolate_lowest(
     }
 
     // recurse
-    struct avl_el* retval = isolate_lowest(&(*root)->l);
+    struct avl_el* retval = isolate_leftmost(&(*root)->l);
 
     // if the recursion solved the problem already, we can return
     if (retval) {

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -60,12 +60,12 @@ rotate_right(
 /**
  * Isolate the root node of a given subtree
  *
- * @return the new root node for the tree of which the old one was the root
+ * @return the new root node of the subtree
  * @warning This function will crash when being passed NULL.
  */
 static struct avl_el*
 isolate_root_node(
-    struct avl_el* node //!< node to remove
+    struct avl_el* node //!< node to isolate
 );
 
 /**

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -342,7 +342,7 @@ static struct avl_el*
 isolate_root_node(
     struct avl_el* node
 ) {
-    // if the node has no left child, we may use the right one
+    // if the node has no left child, we may use the right one as new root node
     if (!node->l) {
         return node->r;
     }


### PR DESCRIPTION
This PR adds helper functions for `avl_del()`. This will allow a rewrite of PR #71 to accomodate for tree regeneration.
