### PR TITLE
Fix declaration of avl_ndel

### DIFF
--- a/src/libreset/avl.h
+++ b/src/libreset/avl.h
@@ -123,6 +123,8 @@ avl_del(
 unsigned int
 avl_ndel(
     struct avl* el, //!< The avl where to search in
+    r_predf pred, //!< A predicate selecting what to remove
+    void* etc, //!< User-data to pass to the predicate
     struct r_set_cfg* cfg //!< type information provided by the user
 );
 


### PR DESCRIPTION
This PR fixes the interface of `avl_ndel()` by adding a predicate.
