### PR TITLE
Added (missing) entry for set.c in CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCE_FILES
     libreset/ht.c
     libreset/bloom.c
     libreset/ll.c
+    libreset/set.c
 )
 
 #


### PR DESCRIPTION
Should be merged before #181, #182, #183 and #184, so they can be
rebased onto this and so the CI actually test compiles patches
in these PRs, too.
