### PR TITLE
Fix AVL insert

### DIFF
--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -202,7 +202,7 @@ avl_insert(
     avl_dbg("Adding element %p with hash: 0x%x", d, hash);
 
     int retval = insert_element_into_tree(d, hash, &avl->root, cfg);
-    rebalance_subtree(avl->root);
+    avl->root = rebalance_subtree(avl->root);
 
     return retval;
 }


### PR DESCRIPTION
The result of the `rebalance_subtree()` operation in `avl_insert()` was ignored. Which is bad, since the result is the new root of the AVL.
Seems to "solve" issue #186 (now it crashes, complaining about double-free'ing some int in `test_avl_insert_multiple()`).
