### PR TITLE
Fix: `_find()` functions shouldn't modify parameters, make them const

### DIFF
--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -188,10 +188,10 @@ avl_destroy(
 
 void*
 avl_find(
-    struct avl* avl,
+    struct avl const* avl,
     rs_hash hash,
-    void* const d,
-    struct r_set_cfg* cfg
+    void const* const d,
+    struct r_set_cfg const* cfg
 ) {
     avl_dbg("Finding element for hash: 0x%x", hash);
     struct avl_el* node = find_node(avl, hash);

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -149,7 +149,7 @@ insert_element_into_tree(
  */
 static struct avl_el*
 find_node(
-    struct avl* avl,
+    struct avl const* avl,
     rs_hash hash
 );
 
@@ -540,7 +540,7 @@ regen_metadata(
 
 static struct avl_el*
 find_node(
-    struct avl* avl,
+    struct avl const* avl,
     rs_hash hash
 ) {
     avl_dbg("Finding node with hash: 0x%x", hash);

--- a/src/libreset/avl.h
+++ b/src/libreset/avl.h
@@ -124,10 +124,10 @@ avl_ndel(
  */
 void*
 avl_find(
-    struct avl* avl, //!< The avl where to search in
+    struct avl const* avl, //!< The avl where to search in
     rs_hash hash, //!< The hash value associated with d
-    void* const d, //!< The data element to compare to
-    struct r_set_cfg* cfg //!< type information proveded by the user
+    void const* const d, //!< The data element to compare to
+    struct r_set_cfg const* cfg //!< type information proveded by the user
 );
 
 /**

--- a/src/libreset/ht.c
+++ b/src/libreset/ht.c
@@ -44,10 +44,10 @@ ht_del(
 
 void*
 ht_find(
-    struct ht* ht,
+    struct ht const* ht,
     rs_hash hash,
-    void* cmp,
-    struct r_set_cfg* cfg
+    void const* cmp,
+    struct r_set_cfg const* cfg
 ) {
     size_t i = hash >> (sizeof(hash) - ht->sizeexp);
     return avl_find(&ht->buckets[i].avl, hash, cmp, cfg);

--- a/src/libreset/ht.h
+++ b/src/libreset/ht.h
@@ -90,10 +90,10 @@ ht_destroy(
  */
 void*
 ht_find(
-    struct ht* ht, //!< The hashtable object to search in
+    struct ht const* ht, //!< The hashtable object to search in
     rs_hash hash, //!< The hash of the element to find
-    void* cmp, //!< Element to compare against
-    struct r_set_cfg* cfg //!< type information provided by user
+    void const* cmp, //!< Element to compare against
+    struct r_set_cfg const* cfg //!< type information provided by user
 );
 
 /**


### PR DESCRIPTION
Because of this I'm having a hard time implementing `r_set_contains()`
(for example).
