### PR TITLE
Fix: The `_del()` and `_ndel()` operations shouldn't be able to alter cfg or cmp element

### DIFF
--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -239,7 +239,7 @@ avl_ndel(
     struct avl* el,
     r_predf pred,
     void* etc,
-    struct r_set_cfg* cfg
+    struct r_set_cfg const* cfg
 ) {
     unsigned int retval = delete_elements_by_predicate(&el->root, pred, etc, cfg);
     el->root = rebalance_subtree(el->root);

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -164,7 +164,7 @@ delete_elements_by_predicate(
     struct avl_el** root,
     r_predf pred,
     void* etc,
-    struct r_set_cfg* cfg
+    struct r_set_cfg const* cfg
 );
 
 /*
@@ -569,7 +569,7 @@ delete_elements_by_predicate(
     struct avl_el** root,
     r_predf pred,
     void* etc,
-    struct r_set_cfg* cfg
+    struct r_set_cfg const* cfg
 ) {
     // check whether the subtree is empty
     if (!*root) {

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -75,8 +75,8 @@ static int
 remove_element(
     struct avl_el** root, //!< The avl where to search in
     rs_hash hash, //!< hash value associated with d
-    void* cmp, //!< element to compare against
-    struct r_set_cfg* cfg //!< type information provided by the user
+    void const* cmp, //!< element to compare against
+    struct r_set_cfg const* cfg //!< type information provided by the user
 );
 
 /**
@@ -421,8 +421,8 @@ static int
 remove_element(
     struct avl_el** root,
     rs_hash hash,
-    void* cmp,
-    struct r_set_cfg* cfg
+    void const* cmp,
+    struct r_set_cfg const* cfg
 ) {
     avl_dbg("Remove element with hash: 0x%x", hash);
 

--- a/src/libreset/avl.c
+++ b/src/libreset/avl.c
@@ -225,8 +225,8 @@ int
 avl_del(
     struct avl* avl,
     rs_hash hash,
-    void* cmp,
-    struct r_set_cfg* cfg
+    void const* cmp,
+    struct r_set_cfg const* cfg
 ) {
     avl_dbg("Deleting element with hash: 0x%x", hash);
     int retval = remove_element(&avl->root, hash, cmp, cfg);

--- a/src/libreset/avl.h
+++ b/src/libreset/avl.h
@@ -93,8 +93,8 @@ int
 avl_del(
     struct avl* avl, //!< The avl where to search in
     rs_hash hash, //!< hash value
-    void* cmp, //!< element to compare against
-    struct r_set_cfg* cfg //!< type information provided by the user
+    void const* cmp, //!< element to compare against
+    struct r_set_cfg const* cfg //!< type information provided by the user
 );
 
 /**

--- a/src/libreset/avl.h
+++ b/src/libreset/avl.h
@@ -112,7 +112,7 @@ avl_ndel(
     struct avl* el, //!< The avl where to search in
     r_predf pred, //!< A predicate selecting what to remove
     void* etc, //!< User-data to pass to the predicate
-    struct r_set_cfg* cfg //!< type information provided by the user
+    struct r_set_cfg const* cfg //!< type information provided by the user
 );
 
 /**

--- a/src/libreset/ht.c
+++ b/src/libreset/ht.c
@@ -35,8 +35,8 @@ int
 ht_del(
     struct ht* ht,
     rs_hash hash,
-    void* cmp,
-    struct r_set_cfg* cfg
+    void const* cmp,
+    struct r_set_cfg const* cfg
 ) {
     size_t i = hash >> (sizeof(rs_hash) - ht->sizeexp);
     return avl_del(&ht->buckets[i].avl, hash, cmp, cfg);

--- a/src/libreset/ht.h
+++ b/src/libreset/ht.h
@@ -122,8 +122,8 @@ int
 ht_del(
     struct ht* ht, //!< The hashtable object to delete from
     rs_hash hash, //!< The hash of the element to delete
-    void* cmp, //!< Element to compare against
-    struct r_set_cfg* cfg //!< type information provided by user
+    void const* cmp, //!< Element to compare against
+    struct r_set_cfg const* cfg //!< type information provided by user
 );
 
 /**

--- a/src/libreset/ll.c
+++ b/src/libreset/ll.c
@@ -142,7 +142,7 @@ ll_ndel(
     struct ll* ll,
     r_predf pred,
     void* etc,
-    struct r_set_cfg* cfg
+    struct r_set_cfg const* cfg
 ) {
     struct ll_element** iter = &ll->head;
     unsigned int cnt = 0;

--- a/src/libreset/ll.c
+++ b/src/libreset/ll.c
@@ -108,8 +108,8 @@ ll_find(
 int
 ll_delete(
     struct ll* ll,
-    void* del,
-    struct r_set_cfg* cfg
+    void const* del,
+    struct r_set_cfg const* cfg
 ) {
     struct ll_element** iter = &ll->head;
     ll_dbg("Deleting from %p", ll);

--- a/src/libreset/ll.h
+++ b/src/libreset/ll.h
@@ -137,7 +137,7 @@ ll_ndel(
     struct ll* ll, //!< Ptr to the linked list object
     r_predf pred, //!< Predicate for deleting elements
     void* etc, //!< User data for the predicate function
-    struct r_set_cfg* cfg //!< type information proveded by the user
+    struct r_set_cfg const* cfg //!< type information proveded by the user
 )
 __nonnull__(1, 4)
 ;

--- a/src/libreset/ll.h
+++ b/src/libreset/ll.h
@@ -119,8 +119,8 @@ __nonnull__(1, 2, 3)
 int
 ll_delete(
     struct ll* ll, //! Ptr to the linked list object
-    void* del, //!< Comparable to object to be removed
-    struct r_set_cfg* cfg //!< type information proveded by the user
+    void const* del, //!< Comparable to object to be removed
+    struct r_set_cfg const* cfg //!< type information proveded by the user
 )
 __nonnull__(1, 2, 3)
 ;


### PR DESCRIPTION
The name of this branch maybe is confusing, but follows the naming schemes
of the other PRs which do similar work.
