### PR TITLE
Fix paper build

### DIFF
--- a/paper/CMakeLists.txt
+++ b/paper/CMakeLists.txt
@@ -22,8 +22,8 @@ set(TEX_FILES
 #
 add_custom_command(
     OUTPUT main.pdf
-    COMMAND pdflatex main
-    COMMAND pdflatex main
+    COMMAND pdflatex -halt-on-error main
+    COMMAND pdflatex -halt-on-error main
     MAIN_DEPENDENCY main.tex
     DEPENDS figures ${TEX_FILES}
 )

--- a/paper/fig/CMakeLists.txt
+++ b/paper/fig/CMakeLists.txt
@@ -12,7 +12,7 @@ foreach(file_in ${MP_FILES})
     string(REPLACE ".mp" ".1" file_out ${file_in})
     add_custom_command(
         OUTPUT ${file_out}
-        COMMAND mpost ${file_in}
+        COMMAND mpost -halt-on-error ${file_in}
         MAIN_DEPENDENCY ${file_in}
     )
     list(APPEND mp_figs ${file_out})


### PR DESCRIPTION
This PR adds some flags to the `mpost`\- and `pdflatex`-involcations for better error handling.
