### PR TITLE
The conditional indent setting for astyle was wrong

### DIFF
--- a/etc/astylerc
+++ b/etc/astylerc
@@ -60,7 +60,7 @@
 #     foo++;
 # }
 #
---min-conditional-indent=1
+--min-conditional-indent=2
 
 #
 # ... don't really get what this does...

--- a/src/libreset/avl/common.c
+++ b/src/libreset/avl/common.c
@@ -59,7 +59,7 @@ rebalance_subtree(
 
     // check whether the subtrees is already balanced (see paper)
     if (avl_node_cnt(root) >
-        (unsigned int) (1 << (avl_height(root) - 1) ) - 1) {
+            (unsigned int) (1 << (avl_height(root) - 1) ) - 1) {
         avl_dbg("Subtree already balanced for %p", root);
         return root;
     }


### PR DESCRIPTION
This:

``` C
if (foo ||
    bar) {
    baz();
}
```

is not really readable. Format like so:

``` C
if (foo ||
        bar) {
    baz();
}
```
