### PR TITLE
Implementation for r_set_equal()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,17 +13,21 @@ include_directories(${PROJECT_SOURCE_DIR}/src/libreset)
 # files.
 #
 set(SOURCE_FILES
-    libreset/avl/base.c
-    libreset/avl/common.c
     libreset/avl/avl_cardinality.c
     libreset/avl/avl_select.c
+    libreset/avl/avl_is_subset.c
+    libreset/avl/base.c
+    libreset/avl/common.c
+    libreset/bloom.c
     libreset/ht/base.c
     libreset/ht/ht_cardinality.c
+    libreset/ht/ht_equal.c
     libreset/ht/ht_select.c
-    libreset/bloom.c
     libreset/ll/base.c
     libreset/ll/ll_count.c
+    libreset/ll/ll_equal.c
     libreset/ll/ll_select.c
+    libreset/ll/ll_is_subset.c
     libreset/set.c
 )
 

--- a/src/libreset/avl/avl.h
+++ b/src/libreset/avl/avl.h
@@ -196,6 +196,22 @@ __r_warn_unused_result__
 ;
 
 /**
+ * Check if avl_a is a subtree of avl_b
+ *
+ * @memberof avl
+ *
+ * @return 0 if avl_a is a subtree of avl_b or else 1
+ */
+int
+avl_is_subset(
+    struct avl const* avl_a, //!< The first avl object for the comparison
+    struct avl const* avl_b,//!< The second avl object for the comparison
+    struct r_set_cfg const* cfg //!< The set configuration
+)
+__r_nonnull__(1, 2, 3)
+;
+
+/**
  * Get the height of the avl sub tree
  *
  * @memberof avl_el

--- a/src/libreset/avl/avl_is_subset.c
+++ b/src/libreset/avl/avl_is_subset.c
@@ -1,0 +1,54 @@
+#include "avl.h"
+
+
+/**
+ * Checks if node_a is a subset of node_b
+ *
+ * @return 1 if node_a is a subset, else 0
+ */
+static int
+node_is_subset(
+    struct avl_el const* node_a,
+    struct avl_el const* node_b,
+    struct avl_el const* node_b_root,
+    struct r_set_cfg const* cfg
+) {
+    if (!node_a) {
+        // An empty set is always a subset of any other set
+        return 1;
+    }
+
+    if (!node_b) {
+        // However, no empty is a superset of another (non-empty set)
+        return 0;
+    }
+
+    // Recursively go down the tree while taking care of the order of the hashes
+    if (node_a->hash > node_b->hash) {
+        return node_is_subset(node_a->l, node_b, node_b_root, cfg) &&
+            node_is_subset(node_a, node_b->r, node_b_root, cfg);
+    } else if (node_a->hash < node_b->hash) {
+        return node_is_subset(node_a->r, node_b, node_b_root, cfg) &&
+            node_is_subset(node_a, node_b->l, node_b_root, cfg);
+    }
+
+    // Verify that the node is in the tree by going back to the roots
+    return node_is_subset(node_a->l, node_b_root, node_b_root, cfg) &&
+            node_is_subset(node_a->r, node_b_root, node_b_root, cfg) &&
+            ll_is_subset(&node_a->ll, &node_b->ll, cfg);
+}
+
+
+int
+avl_is_subset(
+    struct avl const* avl_a,
+    struct avl const* avl_b,
+    struct r_set_cfg const* cfg
+) {
+    if (!avl_a) {
+        // An empty set is always a subset of another
+        return 1;
+    }
+
+    return node_is_subset(avl_a->root, avl_b->root, avl_b->root, cfg);
+}

--- a/src/libreset/ht/ht.h
+++ b/src/libreset/ht/ht.h
@@ -192,6 +192,22 @@ __r_nonnull__(1, 4)
 ;
 
 /**
+ * Check if two hashtable objects are equal (containing equal elements)
+ *
+ * @memberof ht
+ *
+ * @return 1 if the hashtables are equal, else 0 (zero)
+ */
+int
+ht_equal(
+    struct ht const* a, //!< The first hashtable for the comparison
+    struct ht const* b, //!< The second hashtable for the comparison
+    struct r_set_cfg const* cfg
+)
+__r_nonnull__(1, 2)
+;
+
+/**
  * Helper to calculate the actual bucket count of the hashtable
  *
  * @memberof ht

--- a/src/libreset/ht/ht_equal.c
+++ b/src/libreset/ht/ht_equal.c
@@ -1,0 +1,61 @@
+#include "ht/ht.h"
+
+int
+ht_equal(
+    struct ht const* ht_a,
+    struct ht const* ht_b,
+    struct r_set_cfg const* cfg
+) {
+    // Two sets who have different amount of elements are never equal
+    if (ht_cardinality(ht_a) != ht_cardinality(ht_b)) {
+        return 0;
+    }
+
+    if (ht_a->sizeexp != ht_b->sizeexp) {
+        // We switch the pointers so they are always ordered in the same way
+        if (ht_a->sizeexp < ht_b->sizeexp) {
+            struct ht const* ht_tmp = ht_a;
+            ht_a = ht_b;
+            ht_b = ht_tmp;
+        }
+        int denom_buckets = 1 << (ht_a->sizeexp - ht_b->sizeexp);
+
+        // We verify that all the buckets have the same cardinality with their
+        // corresponding one
+        int i = ht_nbuckets(ht_b);
+        while (i--) {
+            size_t size = 0;
+            int j = denom_buckets;
+            while (j--) {
+                size += avl_cardinality(&ht_a->buckets[denom_buckets*i +j].avl);
+            }
+            if (size != avl_cardinality(&ht_b->buckets[i].avl)) {
+                return 0;
+            }
+        }
+
+        // All the avls have the same cardinality, now we check if each element
+        // is present in each other bucket
+        i = ht_nbuckets(ht_b);
+        while (i--) {
+            int j = denom_buckets;
+            while (j--) {
+                if (!avl_is_subset(&ht_a->buckets[denom_buckets*i +j].avl,
+                        &ht_b->buckets[i].avl, cfg)) {
+                    return 0;
+                }
+            }
+        }
+    } else {
+        int i = ht_nbuckets(ht_b);
+        while (i--) {
+            if (!avl_is_subset(&ht_a->buckets[i].avl,
+                    &ht_b->buckets[i].avl, cfg)) {
+                return 0;
+            }
+        }
+    }
+
+    return 1;
+}
+

--- a/src/libreset/ll/base.c
+++ b/src/libreset/ll/base.c
@@ -91,7 +91,7 @@ ll_insert(
 
 void*
 ll_find(
-    struct ll* ll,
+    struct ll const* ll,
     void const* const d,
     struct r_set_cfg const* cfg
 ) {

--- a/src/libreset/ll/ll.h
+++ b/src/libreset/ll/ll.h
@@ -114,6 +114,22 @@ __r_warn_unused_result__
 ;
 
 /**
+ * Check if ll_a is a subset of ll_b
+ *
+ * @memberof ll
+ *
+ * @return 0 if ll_a is a subset of ll_b else a 1
+ */
+int
+ll_is_subset(
+    struct ll const* ll_a, //!< The linked list to search in
+    struct ll const* ll_b, //!< The linked list to search in
+    struct r_set_cfg const* cfg //!< Type information provided by the user
+)
+__r_nonnull__(1, 2, 3)
+;
+
+/**
  * Delete an item from the list
  *
  * @memberof ll

--- a/src/libreset/ll/ll.h
+++ b/src/libreset/ll/ll.h
@@ -105,7 +105,7 @@ __r_warn_unused_result__
  */
 void*
 ll_find(
-    struct ll* ll, //!< The linked list to search in
+    struct ll const* ll, //!< The linked list to search in
     void const* const d, //!< Data element to compare to
     struct r_set_cfg const* cfg //!< Type information provided by the user
 )

--- a/src/libreset/ll/ll.h
+++ b/src/libreset/ll/ll.h
@@ -225,6 +225,22 @@ __r_nonnull__(1, 4)
 ;
 
 /**
+ * Check whether two linked list objects are equal
+ *
+ * @memberof ll
+ *
+ * @return 1 if the lists are equal, else 0 (zero)
+ */
+int
+ll_equal(
+    struct ll const* lla, //!< The first linked list to compare
+    struct ll const* llb, //!< The second linked list to compare
+    struct r_set_cfg const* cfg //!< Type information provided by the user
+)
+__r_nonnull__(1, 2)
+;
+
+/**
  * @}
  */
 

--- a/src/libreset/ll/ll_equal.c
+++ b/src/libreset/ll/ll_equal.c
@@ -1,0 +1,24 @@
+#include "ll/ll.h"
+
+int
+ll_equal(
+    struct ll const* lla,
+    struct ll const* llb,
+    struct r_set_cfg const* cfg //!< Type information provided by the user
+) {
+    if (lla == llb) {
+        return 1;
+    }
+
+    if ((lla == NULL) ^ (llb == NULL)) {
+        return 0;
+    }
+
+    ll_foreach(it_a, lla) {
+        if (NULL == ll_find(llb, it_a->data, cfg)) {
+            return 0;
+        }
+    }
+
+    return 1;
+}

--- a/src/libreset/ll/ll_is_subset.c
+++ b/src/libreset/ll/ll_is_subset.c
@@ -1,0 +1,20 @@
+#include "ll.h"
+
+int
+ll_is_subset(
+    struct ll const* ll_a,
+    struct ll const* ll_b,
+    struct r_set_cfg const* cfg
+) {
+    if (!ll_a) {
+        return 1;
+    }
+
+    ll_foreach(it, ll_a) {
+        if (!ll_find(ll_b, it->data, cfg)) {
+            return 0;
+        }
+    }
+
+    return 1;
+}

--- a/src/libreset/set.c
+++ b/src/libreset/set.c
@@ -126,3 +126,23 @@ r_set_select(
     return ht_select(&src->ht, pred, pred_etc, procf, dest);
 }
 
+int
+r_set_equal(
+    struct r_set const* set_a,
+    struct r_set const* set_b
+) {
+    if (set_a == set_b) {
+        return 1;
+    }
+
+    if (!(set_a && set_b)) {
+        return 0;
+    }
+
+    if (!config_cmp(set_a->cfg, set_b->cfg)) {
+        return 0;
+    }
+
+    return ht_equal(&set_a->ht, &set_b->ht, set_a->cfg);
+}
+

--- a/tests/avl/avl_tests.c
+++ b/tests/avl/avl_tests.c
@@ -239,6 +239,44 @@ START_TEST (test_avl_cardinality_continuous) {
 }
 END_TEST
 
+START_TEST (test_avl_subset) {
+    struct avl* avl = calloc(1, sizeof(*avl));
+
+    int data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    r_hash hash[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+    int i;
+    for (i = 0; i < 10; i++) {
+        avl_insert(avl, hash[i], &data[i], &cfg_int);
+    }
+
+    ck_assert(avl_is_subset(avl, avl, &cfg_int) == 1);
+    avl_destroy(avl, &cfg_int);
+}
+END_TEST
+
+START_TEST (test_avl_subset_distinct) {
+    struct avl* avl = calloc(1, sizeof(*avl));
+    struct avl* avl2 = calloc(1, sizeof(*avl2));
+
+    int data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    int data2[] = { 0, 1, 2, 3 };
+    r_hash hash[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+    int i;
+    for (i = 0; i < 10; i++) {
+        avl_insert(avl, hash[i], &data[i], &cfg_int);
+    }
+    for (i = 0; i < 4; i++) {
+        avl_insert(avl2, hash[i], &data2[i], &cfg_int);
+    }
+
+    ck_assert(avl_is_subset(avl2, avl, &cfg_int) == 1);
+    ck_assert(avl_is_subset(avl, avl2, &cfg_int) != 1);
+    avl_destroy(avl, &cfg_int);
+}
+END_TEST
+
 Suite*
 suite_avl_create(void) {
     Suite* s;
@@ -246,6 +284,7 @@ suite_avl_create(void) {
     TCase* case_adding;
     TCase* case_deleting;
     TCase* case_finding;
+    TCase* case_subset;
 
     s = suite_create("AVL");
 
@@ -254,6 +293,7 @@ suite_avl_create(void) {
     case_adding     = tcase_create("Adding");
     case_deleting   = tcase_create("Deleting");
     case_finding    = tcase_create("Finding");
+    case_subset     = tcase_create("Finding");
 
     /* test adding to test cases */
     tcase_add_test(case_allocfree, test_avl_alloc_destroy);
@@ -274,11 +314,15 @@ suite_avl_create(void) {
     tcase_add_test(case_finding, test_avl_cardinality);
     tcase_add_test(case_finding, test_avl_cardinality_continuous);
 
+    tcase_add_test(case_subset, test_avl_subset);
+    tcase_add_test(case_subset, test_avl_subset_distinct);
+
     /* Adding test cases to suite */
     suite_add_tcase(s, case_allocfree);
     suite_add_tcase(s, case_adding);
     suite_add_tcase(s, case_deleting);
     suite_add_tcase(s, case_finding);
+    suite_add_tcase(s, case_subset);
 
     return s;
 }

--- a/tests/ll/ll_test.c
+++ b/tests/ll/ll_test.c
@@ -134,7 +134,7 @@ START_TEST (test_ll_is_empty_after_insertion_and_deletion) {
 END_TEST
 
 START_TEST (test_ll_count) {
-    struct ll* ll = malloc(sizeof(*ll));
+    struct ll* ll = calloc(1, sizeof(*ll));
     int i;
     int data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
@@ -147,12 +147,68 @@ START_TEST (test_ll_count) {
 }
 END_TEST
 
+START_TEST (test_ll_subset) {
+    struct ll* ll = calloc(1, sizeof(*ll));
+    int i;
+    int data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+    for (i = 0; i < 10; i++) {
+        ck_assert(ll_insert(ll, &(data[i]), &cfg_int) == 0);
+    }
+
+    ck_assert(ll_is_subset(ll, ll, &cfg_int) == 1);
+
+    ll_destroy(ll, &cfg_int);
+}
+END_TEST
+
+START_TEST (test_ll_subset_distinct_wrong) {
+    struct ll* ll = calloc(1, sizeof(*ll));
+    struct ll* ll2 = calloc(1, sizeof(*ll2));
+    int i;
+    int data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    int data2[] = { 0, 1, 2, 3, 4, 5, 6,    8, 9, 10 };
+
+    for (i = 0; i < 10; i++) {
+        ck_assert(ll_insert(ll, &(data[i]), &cfg_int) == 0);
+        ck_assert(ll_insert(ll2, &(data2[i]), &cfg_int) == 0);
+    }
+
+    ck_assert(ll_is_subset(ll2, ll, &cfg_int) != 1);
+    ck_assert(ll_is_subset(ll, ll2, &cfg_int) != 1);
+
+    ll_destroy(ll, &cfg_int);
+}
+END_TEST
+
+START_TEST (test_ll_subset_distinct) {
+    struct ll* ll = calloc(1, sizeof(*ll));
+    struct ll* ll2 = calloc(1, sizeof(*ll2));
+    int i;
+    int data[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+    int data2[] = { 0, 1, 2, 3 };
+
+    for (i = 0; i < 10; i++) {
+        ck_assert(ll_insert(ll, &(data[i]), &cfg_int) == 0);
+    }
+    for (i = 0; i < 4; i++) {
+        ck_assert(ll_insert(ll2, &(data2[i]), &cfg_int) == 0);
+    }
+
+    ck_assert(ll_is_subset(ll2, ll, &cfg_int) == 1);
+    ck_assert(ll_is_subset(ll, ll2, &cfg_int) != 1);
+
+    ll_destroy(ll, &cfg_int);
+}
+END_TEST
+
 Suite*
 suite_ll_create(void) {
     Suite* s;
     TCase* case_insert;
     TCase* case_delete;
     TCase* case_empty;
+    TCase* case_subset;
 
     s = suite_create("Linkedlist");
 
@@ -160,6 +216,7 @@ suite_ll_create(void) {
     case_insert         = tcase_create("Inserting");
     case_delete         = tcase_create("Deleting");
     case_empty          = tcase_create("Emptyness");
+    case_subset          = tcase_create("Subset");
 
     /* test adding */
     tcase_add_test(case_insert, test_ll_insert_data);
@@ -172,10 +229,15 @@ suite_ll_create(void) {
     tcase_add_test(case_empty, test_ll_is_empty_after_insertion_and_deletion);
     tcase_add_test(case_delete, test_ll_count);
 
+    tcase_add_test(case_subset, test_ll_subset);
+    tcase_add_test(case_subset, test_ll_subset_distinct);
+    tcase_add_test(case_subset, test_ll_subset_distinct_wrong);
+
     /* Adding test cases to suite */
     suite_add_tcase(s, case_insert);
     suite_add_tcase(s, case_delete);
     suite_add_tcase(s, case_empty);
+    suite_add_tcase(s, case_subset);
 
     return s;
 }

--- a/tests/set/set_tests.c
+++ b/tests/set/set_tests.c
@@ -13,21 +13,42 @@ START_TEST (test_r_set_cardinality) {
 }
 END_TEST
 
+START_TEST (test_r_set_equal) {
+    struct r_set* set = r_set_new(&cfg_int);
+    struct r_set* set2 = r_set_new(&cfg_int);
+    int data = 1;
+    r_set_insert(set, &data);
+    ck_assert(1 != r_set_equal(set, set2));
+
+    r_set_insert(set2, &data);
+    ck_assert(1 == r_set_equal(set, set2));
+
+    int data2 = 2;
+    r_set_insert(set2, &data2);
+    ck_assert(1 != r_set_equal(set, set2));
+}
+END_TEST
+
 Suite*
 suite_set_create(void) {
     Suite* s;
     TCase* case_cardinality;
+    TCase* case_equality;
 
     s = suite_create("Set");
 
     /* Test case creation */
     case_cardinality  = tcase_create("Cardinality");
+    case_equality     = tcase_create("Equality");
 
     /* test adding to test cases */
     tcase_add_test(case_cardinality, test_r_set_cardinality);
 
+    tcase_add_test(case_equality, test_r_set_equal);
+
     /* Adding test cases to suite */
     suite_add_tcase(s, case_cardinality);
+    suite_add_tcase(s, case_equality);
 
     return s;
 }

--- a/tests/set_cfg.c
+++ b/tests/set_cfg.c
@@ -2,6 +2,7 @@
 
 #include "libreset/hash.h"
 
+#include <stdint.h>
 
 static r_hash hashf(void const*);
 static int cmpf(void const*, void const*);
@@ -17,7 +18,7 @@ struct r_set_cfg cfg_int = {
 
 
 static r_hash hashf(void const* d) {
-    return *((int*) d);
+    return SIZE_MAX / (*((int*) d)/2+1) ;
 }
 
 static int cmpf(void const* a, void const* b) {


### PR DESCRIPTION
This PR is a WIP for adding the implementation of `r_set_equal()` along with
the internal helpers and therefor targets #174 .

@neithernut I would like to have some pointers on how to approach this.
I don't think I have to do a complex operation where I loop in O(n^2)
trough all ht buckets and inside that in O(n^2) through all avl nodes,
and again, inside that one in O(n^2) through all linked lists? Seems
really much to complex for me to be the way how this has to be solved...
