### PR TITLE
Added a NULL check to avl_find

### DIFF
--- a/src/libreset/avl/base.c
+++ b/src/libreset/avl/base.c
@@ -97,6 +97,10 @@ avl_find(
     avl_dbg("Finding element for hash: 0x%x", hash);
     struct avl_el* node = find_node(avl, hash);
 
+    if(!node) {
+        return NULL;
+    }
+
     return ll_find(&node->ll, d, cfg);
 }
 


### PR DESCRIPTION
This fixes a segfault in avl_find if a node is not found.
