### PR TITLE
Added simplification for bucket index equation

### DIFF
--- a/paper/data-layout.tex
+++ b/paper/data-layout.tex
@@ -26,6 +26,7 @@
 
         \begin{equation}
             s \in \left\{ 2^n | n \in \mathbb{N} \right\}
+            \label{eq:num_of_buckets}
         \end{equation}
 
         Assume having two hashtables $A$ and $B$, where the number of buckets of
@@ -64,6 +65,12 @@
 
         \begin{equation}
             i \in e(b_n) \qquad j = h(i) \div \frac{2^N}{s}
+        \end{equation}
+
+        Using equation \ref{eq:num_of_buckets}, this can be transformed to:
+
+        \begin{equation}
+            j = h(i) \div \frac{2^N}{2^n} = h(i) \div 2^{N - n}
         \end{equation}
 
         Where $N$ is the number of bits of a hash-value.

--- a/paper/data-layout.tex
+++ b/paper/data-layout.tex
@@ -63,7 +63,7 @@
         However, we are using the \em most\em{} significant bits:
 
         \begin{equation}
-            i \in e(b_n) \qquad n = h(i) \div \frac{2^N}{s}
+            i \in e(b_n) \qquad j = h(i) \div \frac{2^N}{s}
         \end{equation}
 
         Where $N$ is the number of bits of a hash-value.


### PR DESCRIPTION
The problem with the "old" equation was, that you cannot implement it in
C as-is. You have to transform the equation into the form which is added
by this PR to get it compiling.

For referencing, this simplification should be added in the paper, too.
