### PR TITLE
Added a missing bitcount operator

### DIFF
--- a/src/libreset/ht/base.c
+++ b/src/libreset/ht/base.c
@@ -76,6 +76,6 @@ ht_insert(
     struct r_set_cfg const* cfg
 ) {
     rs_hash hash = cfg->hashf(data);
-    size_t i = hash >> (sizeof(hash) - ht->sizeexp);
+    size_t i = hash >> (BITCOUNT(hash) - ht->sizeexp);
     return avl_insert(&ht->buckets[i].avl, hash, data, cfg);
 }

--- a/src/libreset/ht/base.c
+++ b/src/libreset/ht/base.c
@@ -76,6 +76,9 @@ ht_insert(
     struct r_set_cfg const* cfg
 ) {
     rs_hash hash = cfg->hashf(data);
+
+    // this is equivalent to hash / 2^(BITCOUNT(hash) - ht->sizeexp) due to the
+    // right shift
     size_t i = hash >> (BITCOUNT(hash) - ht->sizeexp);
     return avl_insert(&ht->buckets[i].avl, hash, data, cfg);
 }


### PR DESCRIPTION
This fixes a bug in `ht_insert`.

This bug made it really unclear which bucket was selected. If it worked before than it was pure luck, as it was undefined behaviour.
