### PR TITLE
Add build debug flag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,6 +33,11 @@ if(${HARD_MODE})
 endif()
 
 #
+# Debugging options
+#
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
+
+#
 # Libreset will be a shared object
 #
 add_library(reset SHARED ${SOURCE_FILES})

--- a/src/libreset/avl/base.c
+++ b/src/libreset/avl/base.c
@@ -219,7 +219,7 @@ remove_element(
 
     // remove the node if neccessary
     if (ll_is_empty(&(*root)->ll)) {
-        avl_dbg("Remove node from tree: %p", *root);
+        avl_dbg("Remove node from tree: %p", (void*) *root);
         // isolate the node
         struct avl_el* to_del = *root;
         *root = isolate_root_node(to_del);
@@ -254,7 +254,7 @@ delete_elements_by_predicate(
 
     // remove the node if neccessary
     if (ll_is_empty(&(*root)->ll)) {
-        avl_dbg("Remove node from tree: %p", *root);
+        avl_dbg("Remove node from tree: %p", (void*) *root);
         // isolate the node
         struct avl_el* to_del = *root;
         *root = isolate_root_node(to_del);

--- a/src/libreset/avl/base.c
+++ b/src/libreset/avl/base.c
@@ -86,7 +86,7 @@ avl_find(
     void const* const d,
     struct r_set_cfg const* cfg
 ) {
-    avl_dbg("Finding element for hash: 0x%x", hash);
+    avl_dbg("Finding element for hash: 0x%zx", hash);
     struct avl_el* node = find_node(avl, hash);
 
     if (!node) {
@@ -103,7 +103,7 @@ avl_insert(
     void* const d, //!< The data element
     struct r_set_cfg const* cfg
 ) {
-    avl_dbg("Adding element %p with hash: 0x%x", d, hash);
+    avl_dbg("Adding element %p with hash: 0x%zx", d, hash);
 
     int retval = insert_element_into_tree(d, hash, &avl->root, cfg);
     avl->root = rebalance_subtree(avl->root);
@@ -118,7 +118,7 @@ avl_del(
     void const* cmp,
     struct r_set_cfg const* cfg
 ) {
-    avl_dbg("Deleting element with hash: 0x%x", hash);
+    avl_dbg("Deleting element with hash: 0x%zx", hash);
     int retval = remove_element(&avl->root, hash, cmp, cfg);
     avl->root = rebalance_subtree(avl->root);
     return retval;
@@ -151,7 +151,7 @@ insert_element_into_tree(
     struct avl_el** root,
     struct r_set_cfg const* cfg
 ) {
-    avl_dbg("Inserting element %p with hash: 0x%x", d, hash);
+    avl_dbg("Inserting element %p with hash: 0x%zx", d, hash);
     int retval;
 
     // we reached the bottom of the tree
@@ -192,7 +192,7 @@ remove_element(
     void const* cmp,
     struct r_set_cfg const* cfg
 ) {
-    avl_dbg("Remove element with hash: 0x%x", hash);
+    avl_dbg("Remove element with hash: 0x%zx", hash);
 
     // check whether the subtree is empty
     if (!*root) {

--- a/src/libreset/avl/common.c
+++ b/src/libreset/avl/common.c
@@ -218,7 +218,7 @@ find_node(
     struct avl const* avl,
     r_hash hash
 ) {
-    avl_dbg("Finding node with hash: 0x%x", hash);
+    avl_dbg("Finding node with hash: 0x%zx", hash);
 
     struct avl_el* iter = avl->root;
     bloom filter = bloom_from_hash(hash);

--- a/src/libreset/avl/common.c
+++ b/src/libreset/avl/common.c
@@ -27,7 +27,7 @@ destroy_subtree(
     struct avl_el* node, //!< A node to destroy
     struct r_set_cfg const* cfg
 ) {
-    avl_dbg("Destroying subtree from node %p", node);
+    avl_dbg("Destroying subtree from node %p", (void*) node);
 
     if (!node) {
         return;
@@ -48,7 +48,7 @@ struct avl_el*
 rebalance_subtree(
     struct avl_el* root
 ) {
-    avl_dbg("Rebalance subtree for %p", root);
+    avl_dbg("Rebalance subtree for %p", (void*) root);
     // check whether the root node is NULL
     if (!root) {
         return NULL;
@@ -57,7 +57,7 @@ rebalance_subtree(
     // check whether the subtrees is already balanced (see paper)
     if (avl_node_cnt(root) >
             (unsigned int) (1 << (avl_height(root) - 1) ) - 1) {
-        avl_dbg("Subtree already balanced for %p", root);
+        avl_dbg("Subtree already balanced for %p", (void*) root);
         return root;
     }
 
@@ -92,7 +92,7 @@ struct avl_el*
 rotate_left(
     struct avl_el* node
 ) {
-    avl_dbg("Rotate left around %p", node);
+    avl_dbg("Rotate left around %p", (void*) node);
     if (!node || !node->r) {
         return node;
     }
@@ -117,7 +117,7 @@ struct avl_el*
 rotate_right(
     struct avl_el* node
 ) {
-    avl_dbg("Rotate right around %p", node);
+    avl_dbg("Rotate right around %p", (void*) node);
     if (!node || !node->l) {
         return node;
     }
@@ -142,7 +142,7 @@ struct avl_el*
 isolate_root_node(
     struct avl_el* node
 ) {
-    avl_dbg("Isolate node from tree: %p", node);
+    avl_dbg("Isolate node from tree: %p", (void*) node);
 
     // if the node has no left child, we may use the right one as new root node
     if (!node->l) {
@@ -172,7 +172,7 @@ isolate_leftmost(
     if (!root || !*root) {
         return NULL;
     }
-    avl_dbg("Isolate leftmost node for tree %p", *root);
+    avl_dbg("Isolate leftmost node for tree %p", (void*) *root);
 
     // recurse
     struct avl_el* retval = isolate_leftmost(&(*root)->l);
@@ -195,7 +195,7 @@ void
 regen_metadata(
     struct avl_el* node //!< The node to regenerate
 ) {
-    avl_dbg("Regenerate metadata for node %p", node);
+    avl_dbg("Regenerate metadata for node %p", (void*) node);
 
     // regenerate the height
     node->height = 1 + MAX(avl_height(node->l), avl_height(node->r));

--- a/src/libreset/ll/base.c
+++ b/src/libreset/ll/base.c
@@ -41,14 +41,14 @@ ll_destroy(
 ) {
     struct ll_element* iter = ll->head;
     struct ll_element* next;
-    ll_dbg("Destroying: %p", ll);
+    ll_dbg("Destroying: %p", (void*) ll);
 
     while (iter) {
         next = iter->next;
         if (cfg->freef) {
             cfg->freef(iter->data);
         }
-        ll_dbg("Removing: %p", iter);
+        ll_dbg("Removing: %p", (void*) iter);
         free(iter);
         iter = next;
     }
@@ -63,11 +63,11 @@ ll_insert(
     // check whether the lement is present or not
     struct ll_element** it = &ll->head;
 
-    ll_dbg("Inserting: %p", data);
+    ll_dbg("Inserting: %p", (void*) data);
 
     while (*it) {
         if (cfg->cmpf((*it)->data, data)) {
-            ll_dbg("already in ll: %p", data);
+            ll_dbg("already in ll: %p", (void*) data);
             return 0;
         }
 
@@ -77,7 +77,7 @@ ll_insert(
     // insert the new element
     struct ll_element* el = calloc(1, sizeof(struct ll_element));
     if (!el) {
-        ll_dbg("Inserting into %p aborted (allocation failed)", ll);
+        ll_dbg("Inserting into %p aborted (allocation failed)", (void*) ll);
         return 0;
     }
 
@@ -112,13 +112,13 @@ ll_delete(
     struct r_set_cfg const* cfg
 ) {
     struct ll_element** iter = &ll->head;
-    ll_dbg("Deleting from %p", ll);
+    ll_dbg("Deleting from %p", (void*) ll);
 
     // iterate over all the elements
     while (*iter) {
         // check whther we have found the element to remove
         if (cfg->cmpf((*iter)->data, del)) {
-            ll_dbg("Deleting element found: %p", *iter);
+            ll_dbg("Deleting element found: %p", (void*) *iter);
             struct ll_element* to_del = (*iter);
 
             // free, relink and return

--- a/src/libreset/ll/base.c
+++ b/src/libreset/ll/base.c
@@ -32,7 +32,7 @@
  * @note No #ifdef DEBUG here, because if dbg() evaluates to nothing, this code
  * gets removed by the compiler anyways.
  */
-#define ll_dbg(fmt,...) do { dbg("[ll]: "fmt, __VA_ARGS); } while (0)
+#define ll_dbg(fmt,...) do { dbg("[ll]: "fmt, __VA_ARGS__); } while (0)
 
 void
 ll_destroy(

--- a/src/libreset/util/debug.h
+++ b/src/libreset/util/debug.h
@@ -52,13 +52,13 @@
  * debug macro which prints the current file, function and the line as well as
  * any given string
  */
-#define dbg(fmt,...) do {                       \
-        fprintf(stderr,                         \
-                "[libreset][%s][%s][%i]: "fmt,  \
-                __FILE__,                       \
-                __func__,                       \
-                __LINE__,                       \
-                __VA_ARGS__);                   \
+#define dbg(fmt,...) do {                           \
+        fprintf(stderr,                             \
+                "[libreset][%s][%s][%i]: "fmt"\n",  \
+                __FILE__,                           \
+                __func__,                           \
+                __LINE__,                           \
+                __VA_ARGS__);                       \
     } while (0)
 
 #else

--- a/src/libreset/util/debug.h
+++ b/src/libreset/util/debug.h
@@ -46,6 +46,7 @@
 #endif
 
 #ifdef DEBUG
+#include <stdio.h>
 
 /**
  * debug macro which prints the current file, function and the line as well as

--- a/src/libreset/util/debug.h
+++ b/src/libreset/util/debug.h
@@ -54,7 +54,7 @@
  */
 #define dbg(fmt,...) do {                       \
         fprintf(stderr,                         \
-                "[libreset][%s][%s][%s]: "fmt,  \
+                "[libreset][%s][%s][%i]: "fmt,  \
                 __FILE__,                       \
                 __func__,                       \
                 __LINE__,                       \


### PR DESCRIPTION
This PR activates the `DEBUG` definition if the build type is `Debug`.
It also aims at fixing the issues surfacing when building with `-DCMAKE_BUILD_TYPE=Debug`.
Note that this PR is both incomplete and blocked by issue #224 atm.
