### PR TITLE
Add build debug output flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_program(DOXYGEN doxygen)
 # Project options
 #
 option(HARD_MODE "Enables extra checks for use during development" OFF)
+option(DEBUG_OUTPUT "Enables debug output, if the built type is \"Debug\"" OFF)
 
 
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,9 @@ endif()
 #
 # Debugging options
 #
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
+if(${DEBUG_OUTPUT})
+    set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
+endif()
 
 #
 # Libreset will be a shared object


### PR DESCRIPTION
This PR solves issue #233 by introducing the option `DEBUG_OUTPUT` (which, by default, is `OFF`).
