### PR TITLE
Modify avl_find to return a pointer to a pointer

### DIFF
--- a/src/libreset/avl/base.c
+++ b/src/libreset/avl/base.c
@@ -90,13 +90,13 @@ avl_find(
     struct r_set_cfg const* cfg
 ) {
     avl_dbg("Finding element for hash: 0x%zx", hash);
-    struct avl_el* node = find_node(avl, hash);
+    struct avl_el** node = find_node(avl, hash);
 
-    if (!node) {
+    if (!*node) {
         return NULL;
     }
 
-    return ll_find(&node->ll, d, cfg);
+    return ll_find(&(*node)->ll, d, cfg);
 }
 
 int

--- a/src/libreset/avl/common.c
+++ b/src/libreset/avl/common.c
@@ -213,26 +213,30 @@ regen_metadata(
     }
 }
 
-struct avl_el*
+struct avl_el**
 find_node(
     struct avl const* avl,
     r_hash hash
 ) {
     avl_dbg("Finding node with hash: 0x%zx", hash);
 
-    struct avl_el* iter = avl->root;
+    struct avl_el** iter = (struct avl_el**) &avl->root;
     bloom filter = bloom_from_hash(hash);
 
-    while (iter && iter->hash != hash) {
+    while (*iter && (*iter)->hash != hash) {
         //check whether the element _can_ be in the subtree
-        if (!bloom_may_contain(filter, iter->filter)) {
-            return NULL;
+        if (!bloom_may_contain(filter, (*iter)->filter)) {
+            // get a NULL-pointer
+            while (*iter) {
+                iter = &(*iter)->l;
+            }
+            return iter;
         }
 
-        if (iter->hash > hash) {
-            iter = iter->l;
+        if ((*iter)->hash > hash) {
+            iter = &(*iter)->l;
         } else {
-            iter = iter->r;
+            iter = &(*iter)->r;
         }
     }
 

--- a/src/libreset/avl/common.h
+++ b/src/libreset/avl/common.h
@@ -116,9 +116,10 @@ __r_warn_unused_result__
 /**
  * Find a node by it's key/hash
  *
- * @return found node or NULL, if the node does not exist
+ * @return pointer to: a pointer to found node or a pointer to NULL, if the node
+ *         does not exist
  */
-struct avl_el*
+struct avl_el**
 find_node(
     struct avl const* avl,
     r_hash hash


### PR DESCRIPTION
This PR modifies `avl_find()`. While previously it returned a pointer to a node or NULL, now it will return a two-level pointer.
This is a prequisite to my work on the `avl_union()` algorithm.
