### PR TITLE
Redefine r_set_select()

### DIFF
--- a/include/libreset/set.h
+++ b/include/libreset/set.h
@@ -55,6 +55,20 @@ typedef int (*r_predf)(void const*, void*);
 
 
 /**
+ * Insertion/processing function
+ *
+ * Use functions of this type if you want to select or process elements of a
+ * set.
+ * The function is expected to return 0 on success and negative values on error.
+ * The first parameter is considered a user defined value (e.g. another set to
+ * insert those values), while the elements will be fed to the function as the
+ * second parameter.
+ */
+typedef int (*r_procf)(void*, void const*);
+
+
+
+/**
  * Allocate and initialize set object
  *
  * @memberof r_set

--- a/include/libreset/set.h
+++ b/include/libreset/set.h
@@ -248,23 +248,37 @@ r_set_cardinality(
 
 
 /**
- * Select entries from a set for a new set
+ * Process selected entries from a set
+ *
+ * This function iterates over all the elements in the set.
+ * First, a predicate (given by pred) is applied.
+ * The first parameter of pred will be the element, while pred_etc will be
+ * passed as the second parameter.
+ * If the predicate function returns 1, the element is selected.
+ * procf will be called, with the value given by dest as the first parameter
+ * and the element to process as the second one.
+ * If the function returns a negative result, no other elements will be
+ * processed.
+ * Instead, the negative (return) value will be passed to the user as the
+ * return value of r_set_select itself.
+ *
+ * If NULL is passed for the predicate, all the elements in the set will be
+ * selected.
  *
  * @memberof r_set
  *
- * The predicate function gets two values passed, the first one is the actual
- * value for the predicate function to check, the second one is the parameter
- * one can pass through the r_set_select() function.
+ * @warning the function will crash if procf is NULL
  *
- * @return zero on success, else error code:
- *         -ENOMEM - if allocation failed
+ * @return 0 or the return value of the last call to procf, if it returned a
+ *         negative value
  */
 int
 r_set_select(
-    struct r_set* dest, //!< destination set
-    struct r_set const* src, //!< source set
-    r_predf pred, //!< predicate for selection
-    void* //!< parameter for the predicate function
+    struct r_set* src, //!< set with elements to process
+    r_predf pred, //!< The predicate
+    void* pred_etc, //!< Additional information for the predicate function
+    r_procf procf, //!< function processing the selected values
+    void* dest //!< some pointer to pass to the procf
 );
 
 #endif //__LIBRESET_H__

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,8 +16,10 @@ set(SOURCE_FILES
     libreset/avl/base.c
     libreset/avl/common.c
     libreset/avl/avl_cardinality.c
+    libreset/avl/avl_select.c
     libreset/ht/base.c
     libreset/ht/ht_cardinality.c
+    libreset/ht/ht_select.c
     libreset/bloom.c
     libreset/ll/base.c
     libreset/ll/ll_count.c

--- a/src/libreset/avl/avl.h
+++ b/src/libreset/avl/avl.h
@@ -168,10 +168,12 @@ int
 avl_select(
     struct avl const* src, //!< The source from where to select
     r_predf pred, //!< The predicate
-    void* etc, //!< Additional information for the predicate function
-    int (*insf)(void* elem, void* insetc), //!< Function to insert somewhere
-    void* insetc //!< additional parameter for `insertf`
-);
+    void* pred_etc, //!< Additional information for the predicate function
+    r_procf procf, //!< function processing the selected values
+    void* dest //!< some pointer to pass to the procf
+)
+__r_nonnull__(1, 4)
+;
 
 /**
  * Get the hash value of an element

--- a/src/libreset/avl/avl_select.c
+++ b/src/libreset/avl/avl_select.c
@@ -4,43 +4,37 @@ static int
 select_from_subtree(
     struct avl_el* root,
     r_predf pred,
-    void* etc,
-    int (*insf)(void* elem, void* insetc),
-    void* insetc
+    void* pred_etc,
+    r_procf procf,
+    void* dest
 ) {
     if (!root) {
         return 0;
     }
 
-    int l = 0;
-    int r = 0;
-    int base = 0;
+    int retval;
 
-    if (root->l) {
-        l = select_from_subtree(root->l, pred, etc, insf, insetc);
+    retval = select_from_subtree(root->l, pred, pred_etc, procf, dest);
+    if (retval < 0) {
+        return retval;
     }
 
-    if (root->r) {
-        r = select_from_subtree(root->r, pred, etc, insf, insetc);
+    retval = select_from_subtree(root->r, pred, pred_etc, procf, dest);
+    if (retval < 0) {
+        return retval;
     }
 
-    base = ll_select(&root->ll, pred, etc, insf, insetc);
-
-    return (base | l | r);
+    return ll_select(&root->ll, pred, pred_etc, procf, dest);
 }
 
 int
 avl_select(
     struct avl const* src,
     r_predf pred,
-    void* etc,
-    int (*insf)(void* elem, void* insetc),
-    void* insetc
+    void* pred_etc,
+    r_procf procf,
+    void* dest
 ) {
-    if (src) {
-        return select_from_subtree(src->root, pred, etc, insf, insetc);
-    }
-
-    return 1;
+    return select_from_subtree(src->root, pred, pred_etc, procf, dest);
 }
 

--- a/src/libreset/ht/ht.h
+++ b/src/libreset/ht/ht.h
@@ -173,12 +173,14 @@ ht_ndel(
  */
 int
 ht_select(
-    struct ht* dest, //!< Destination hashtable object
-    struct ht const* src, //!< Source hashtable object
+    struct ht* src, //!< Destination hashtable object
     r_predf pred, //!< The predicate
-    void* etc, //!< Additional information for the predicate function
-    struct r_set_cfg* const cfg //!< Type information provided by user
-);
+    void* pred_etc, //!< Additional information for the predicate function
+    r_procf procf, //!< function processing the selected values
+    void* dest //!< some pointer to pass to the procf
+)
+__r_nonnull__(1, 4)
+;
 
 /**
  * Helper to calculate the actual bucket count of the hashtable

--- a/src/libreset/ht/ht_select.c
+++ b/src/libreset/ht/ht_select.c
@@ -1,65 +1,23 @@
 #include "ht/ht.h"
 
-/**
- * Helper struct for passing information to `insert()` function
- */
-struct insert_etc_data {
-    struct ht* ht;
-    struct r_set_cfg const* cfg;
-};
-
-/**
- * Helper function to pass around, defining how to insert something into the new
- * set
- *
- * This whole approach is based on this function. This function is passed
- * around. It is used to insert values "somewhere".
- *
- * The idea of the select-functions are: You pass a destination set and a source
- * set. You select _some_ elements from the source set (by predicate) and insert
- * them into the destination set.
- *
- * The insertion is done by this function. The linked list actually calls thif
- * function, if the predicate becomes true for one element. An alternative
- * approach _would_ be to pass the actual `struct r_set*` around, which is kind
- * of ugly.
- *
- * So, this function is passed around. It gets the element to insert (which is a
- * `void*`) and an "etc" value. The "etc" value is used to pass the destination
- * hashtable to it.
- *
- * Without this function, the linked list implementation would need to call
- * `ht_insert()` on a hashtable object it gets.
- *
- * @return 1 on failure, else zero
- */
-static int
-insert(
-    void* element_to_insert, //!< The ptr to the element to insert in the dest
-    void* insert_etc //!< Additional information via `struct insert_etc_data*`
-) {
-    struct insert_etc_data* etc = insert_etc;
-    return (0 == ht_insert(etc->ht, element_to_insert, etc->cfg));
-}
-
 int
 ht_select(
-    struct ht* dest,
-    struct ht const* src,
+    struct ht* src,
     r_predf pred,
-    void* etc,
-    struct r_set_cfg* const cfg
+    void* pred_etc,
+    r_procf procf,
+    void* dest
 ) {
-    size_t i;
-    size_t nbucks = ht_nbuckets(src);
+    size_t i = ht_nbuckets(src);
 
-    struct insert_etc_data etc_data = { .ht = dest, .cfg = cfg };
-
-    for (i = 0; i < nbucks; i++) {
-        if (!avl_select(&src->buckets[i].avl, pred, etc, insert, &etc_data)) {
-            return 1;
+    while (i--) {
+        struct ht_bucket* buck = &src->buckets[i];
+        int retval = avl_select(&buck->avl, pred, pred_etc, procf, dest);
+        if (retval < 0) {
+            return retval;
         }
     }
 
     return 0;
 }
+

--- a/src/libreset/ll/ll.h
+++ b/src/libreset/ll/ll.h
@@ -201,10 +201,12 @@ int
 ll_select(
     struct ll const* src, //!< The source from where to select
     r_predf pred, //!< The predicate
-    void* etc, //!< Additional information for the predicate function
-    int (*insf)(void* elem, void* ins_etc), //!< insert function
-    void* ins_etc //!< additional parameter for `insertf`
-);
+    void* pred_etc, //!< Additional information for the predicate function
+    r_procf procf, //!< function processing the selected values
+    void* dest //!< some pointer to pass to the procf
+)
+__r_nonnull__(1, 4)
+;
 
 /**
  * @}

--- a/src/libreset/ll/ll_select.c
+++ b/src/libreset/ll/ll_select.c
@@ -4,14 +4,15 @@ int
 ll_select(
     struct ll const* src,
     r_predf pred,
-    void* etc,
-    int (*insf)(void* elem, void* ins_etc),
-    void* ins_etc
+    void* pred_etc,
+    r_procf procf,
+    void* dest
 ) {
     ll_foreach(it, src) {
-        if (pred(it->data, etc)) {
-            if (!insf(it->data, ins_etc)) {
-                return 1;
+        if (pred || pred(it->data, pred_etc)) {
+            int retval = procf(dest, it->data);
+            if (retval < 0) {
+                return retval;
             }
         }
     }


### PR DESCRIPTION
This PR brings with it a complete redefinition of `r_set_select()`.
It is now possible to process selected elements using a user defined function or insert selected elements into another set by passing `r_set_insert` as `procf` and the destination set as `dest`.
