### PR TITLE
Update the return for returning errno consts

### DIFF
--- a/src/libreset/avl/base.c
+++ b/src/libreset/avl/base.c
@@ -23,7 +23,7 @@
 /**
  * Remove an element
  *
- * @return 1 if an element was removed, 0 otherwise
+ * @return 0 if an element was removed, negative error code otherwise
  */
 static int
 remove_element(


### PR DESCRIPTION
The indention of the PR was to check that every function returns errno (if
it should return a status).

Actually, only one line in the documentation was wrong, which is fixed by
this PR.
