### PR TITLE
Add config functionality for basic operations

### DIFF
--- a/include/libreset/set.h
+++ b/include/libreset/set.h
@@ -39,7 +39,7 @@ struct r_set;
 struct r_set_cfg {
     r_hash         (*hashf)(void const* data); //!< hash function
     int             (*cmpf)(void const*, void const*); //!< compare function
-    void const*     (*copyf)(void const*); //!< copy function
+    void*           (*copyf)(void*); //!< copy function
     void            (*freef)(void*); //!< function for removal/freeing of an item
 };
 

--- a/src/libreset/ll/base.c
+++ b/src/libreset/ll/base.c
@@ -83,7 +83,12 @@ ll_insert(
         return -ENOMEM;
     }
 
-    el->data = data;
+    if (cfg->copyf) {
+        el->data = cfg->copyf(data);
+    } else {
+        el->data = data;
+    }
+
     *it = el;
 
     return 0;


### PR DESCRIPTION
This PR adds `cfg->copyf()` calls for some basic functions like insert, find and so on in the linked list implementation.

This ensures that the user can do refcounting and other fancy things automatically on insertion/... of elements. 
