### PR TITLE
Fix: Logical OR in ll_select()

### DIFF
--- a/src/libreset/ll/ll_select.c
+++ b/src/libreset/ll/ll_select.c
@@ -9,7 +9,7 @@ ll_select(
     void* dest
 ) {
     ll_foreach(it, src) {
-        if (pred || pred(it->data, pred_etc)) {
+        if (pred && pred(it->data, pred_etc)) {
             int retval = procf(dest, it->data);
             if (retval < 0) {
                 return retval;


### PR DESCRIPTION
If `pred` is `NULL`, the line still tries to execute the function. This
is fixed by this commit.
