### PR TITLE
Fix: The predicates parameter for the current element should not be const

### DIFF
--- a/include/libreset/set.h
+++ b/include/libreset/set.h
@@ -65,7 +65,10 @@ typedef int (*r_predf)(void const*, void*);
  * insert those values), while the elements will be fed to the function as the
  * second parameter.
  */
-typedef int (*r_procf)(void*, void const*);
+typedef int (*r_procf)(
+    void*, //!< `etc` parameter - user defined data
+    void* //!< current element from iteration
+);
 
 
 


### PR DESCRIPTION
The element which gets passed to the processing function shouldn't be `const`.

This PR fixes this.
